### PR TITLE
Corrected the description of a 2-of-3 multisig requiring unanimous consensus

### DIFF
--- a/book/manuscript/Chapter 03 P2SH Script Engineering - From Multi-signature to Time Locks.md
+++ b/book/manuscript/Chapter 03 P2SH Script Engineering - From Multi-signature to Time Locks.md
@@ -53,7 +53,7 @@ Consider a blockchain startup with three key stakeholders:
 - **Bob**: CTO with technical oversight  
 - **Carol**: CFO with financial controls
 
-Their treasury policy requires any two signatures for fund movement, preventing both single-person risk and requiring unanimous consensus.
+Their treasury policy requires any two signatures for fund movement, preventing both single-person risk and requiring authorization by a majority of the stakeholders.
 
 ### Multi-signature Script Construction
 


### PR DESCRIPTION
Both the words "unanimous" and "consensus" imply that every stakeholder needs to authorize the transaction, which would be the case if it was a 3-of-3 multisig, but not with a 2-of-3 multisig.