### PR TITLE
More accurate usage of leaf & branch terminology

### DIFF
--- a/book/manuscript/Chapter 06 Building Real Taproot Contracts - Single-Leaf Hash Lock and Dual-Path Spending.md
+++ b/book/manuscript/Chapter 06 Building Real Taproot Contracts - Single-Leaf Hash Lock and Dual-Path Spending.md
@@ -60,17 +60,17 @@ Before diving into code implementation, we need to understand Taproot's core dev
 **Reveal Phase**:
 - Choose one spending condition for unlocking
 - Key Path: Spend directly with key (maximum privacy)
-- Script Path: Reveal and execute specific script branch
+- Script Path: Reveal and execute specific leaf script
 - **Only expose actually used conditions**, other conditions remain private forever
 
-The power of this pattern lies in: During Commit phase, all contracts of different complexity look identical; During Reveal phase, only the actually used branch needs to be exposed.
+The power of this pattern lies in: During Commit phase, all contracts of different complexity look identical; During Reveal phase, only the actually used leaf script needs to be exposed.
 
 ## Single Leaf Hash Lock Script: From Commit to Reveal
 
 Let's learn the complete implementation flow of Taproot single leaf scripts through a simple Hash Lock case. Based on Alice's conditional payment scenario introduced earlier, we'll implement:
 
 - **Hash Lock Script**: Verify hash value of secret word "helloworld"
-- **Single Leaf Structure**: Simplest script tree containing only one script branch
+- **Single Leaf Structure**: Simplest script tree containing only one leaf script
 - **Dual Path Spending**: Key Path (Alice's direct control) + Script Path (conditional spending)
 
 ### What is Tagged Hash?
@@ -228,7 +228,7 @@ This is exactly the advantage of Schnorr signatures over ECDSA: supporting linea
 
 ### Phase 3: Reveal Phase - Script Path Spending (Conditional Unlock)
 
-Now let's implement the complete code for Script Path spending. Unlike Key Path's simplicity, Script Path requires building more complex witness data to prove we have the right to use a specific script branch.
+Now let's implement the complete code for Script Path spending. Unlike Key Path's simplicity, Script Path requires building more complex witness data to prove we have the right to use a specific leaf script.
 
 ### Script Path Spending Code Implementation
 
@@ -599,7 +599,7 @@ Through actual code implementation and on-chain data analysis, we can clearly se
 | --- | --- | --- |
 | **Witness Data** | 1 element (64-byte signature) | 3 elements (input+script+control block) |
 | **Transaction Size** | ~153 bytes | ~234 bytes |
-| **Privacy Level** | Complete privacy, zero information leakage | Partial privacy, only exposes used script branch |
+| **Privacy Level** | Complete privacy, zero information leakage | Partial privacy, only exposes used leaf script |
 | **Verification Complexity** | Single Schnorr signature verification | Control block verification + script execution |
 | **Fee Cost** | Lowest cost | Medium cost (~50% additional overhead) |
 
@@ -607,7 +607,7 @@ This **selective reveal** design enables Taproot to support various complex appl
 
 ## The Privacy Revolution: What Makes Taproot Different
 
-Unlike P2SH, where **all conditions are revealed** when spending, Taproot Script Path ensures only the executed branch is ever seen. This fundamental shift redefines Bitcoin's privacy model for contracts.
+Unlike P2SH, where **all conditions are revealed** when spending, Taproot Script Path ensures only the executed leaf script is ever seen. This fundamental shift redefines Bitcoin's privacy model for contracts.
 
 **Traditional Script Limitations:**
 - All spending conditions visible on-chain


### PR DESCRIPTION
Technically, one only speaks of a "branch" (a.k.a. internal node) in a P2TR script tree (and Merkle trees in general) when combining two child hashes to form a parent hash. In Taproot specifically, this is when creating a branch hash (using "TapBranch").

Since chapter 6's example only has one leaf script, and the leaf hash is computed using "TapLeaf", the usage of the "branch" terminology is not 100% accurate and can be confusing.

In the context of a complex contract in a P2SH-output, I left the usage of the "unused branches" terminology unchanged, since we're talking about conditional branching there.