### PR TITLE
Fix Schnorr tweak verification

### DIFF
--- a/book/manuscript/Chapter 05 Taproot The Evolution of Bitcoins Script System.md
+++ b/book/manuscript/Chapter 05 Taproot The Evolution of Bitcoins Script System.md
@@ -215,7 +215,6 @@ def demonstrate_key_tweaking():
     print(f"Tweak Integer: {tweak_int}")
 
     # Step 4: Apply tweaking formula
-    internal_privkey_int = int.from_bytes(internal_private_key.to_bytes(), 'big')
     curve_order = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
     internal_privkey_int = int.from_bytes(internal_private_key.to_bytes(), 'big')
     tweaked_privkey_int = (internal_privkey_int + tweak_int) % curve_order
@@ -232,7 +231,7 @@ def demonstrate_key_tweaking():
 
     # Step 5: Verify the mathematical relationship
     print(f"\n=== STEP 5: Mathematical Verification ===")
-    print(f"d' * G == P + tweak_int * G? {tweaked_public_key.to_hex()[2:] == internal_public_key.to_taproot_hex()[0]}")
+    print(f"d' * G == P + tweak_int * G? {tweaked_public_key.to_x_only_hex() == internal_public_key.to_taproot_hex()[0]}")
     print(f"Anyone can compute P' from P and commitment: [OK]")
     print(f"Only key holder can compute d' from d and tweak: [OK]")
 


### PR DESCRIPTION
Builds on #23 

Verifies that a private key and its public key create the same public point after tweaking using different methods.

Compares two methods, `tweaked_public_key.to_x_only_hex()` and `internal_public_key.to_taproot_hex()`, which create a tweaked public key using scalar multiplication of a tweaked private key (known private key + tweak) and point addition of a known public key and a computed tweak point (tweak * generator point), respectively. Both methods arrive at the same tweaked public key.

An earlier implementation compared the public key hex to itself.