### PR TITLE
feat: add tweak explainer section

### DIFF
--- a/book/manuscript/Chapter 05 Taproot The Evolution of Bitcoins Script System.md
+++ b/book/manuscript/Chapter 05 Taproot The Evolution of Bitcoins Script System.md
@@ -247,6 +247,7 @@ def demonstrate_key_tweaking():
 # Execute the demonstration
 result = demonstrate_key_tweaking()
 ```
+
 Under the hood, during `internal_public_key.to_taproot_hex()`, bitcoinutils library executes:
 ```python
 # calculate tweak using HashTapTweak(internal_public_key || script (empty))


### PR DESCRIPTION
Builds on #24 

Adds markdown section clarifying tweak verification code to expose internal library implementation and prove that  the tweaking operation satisfies the linear equation `d * G + tweak * G == (d + tweak) * G` for both library methods.

This section is necessary because the bitcoinutils library abstracts the actual process of obtaining a tweaked public key and I did not want to add new dependencies to the project, although that can be implemented if preferred.