### PR TITLE
Apply standardized transaction link formatting accross chapters 1-6

### DIFF
--- a/book/manuscript/Chapter 02 Bitcoin Script Fundamentals - Stack Operations and P2PKH.md
+++ b/book/manuscript/Chapter 02 Bitcoin Script Fundamentals - Stack Operations and P2PKH.md
@@ -157,7 +157,7 @@ The spender provides:
 
 Let's examine the famous first Bitcoin transaction: Satoshi Nakamoto sending 10 BTC to Hal Finney.
 
-**Transaction ID**: [`f4184fc5...1e9e16`](https://mempool.space/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16)
+**Transaction ID**: [`f4184fc5...831e9e16`](https://mempool.space/tx/f4184fc596403b9d638783cf57adfe4c75c605f6356fbc91338530e9831e9e16?showDetails=true)
 
 **Transaction Structure**:
 
@@ -350,7 +350,7 @@ if __name__ == "__main__":
 
 Let's analyze the actual data from our transaction execution. When this code runs, it produces a real transaction that was broadcast to testnet:
 
-**Transaction ID**: [`bf41b474...8e58355`](https://mempool.space/testnet/tx/bf41b47481a9d1c99af0b62bb36bc864182312f39a3e1e06c8f6304ba8e58355)
+**Transaction ID**: [`bf41b474...a8e58355`](https://mempool.space/testnet/tx/bf41b47481a9d1c99af0b62bb36bc864182312f39a3e1e06c8f6304ba8e58355?showDetails=true)
 
 **Raw Transaction Data**:
 
@@ -484,11 +484,11 @@ Result: SUCCESS (non-zero value on stack)
 ### Transaction Broadcast Result
 
 This transaction was successfully broadcast to the Bitcoin testnet and can be viewed at:
-[`mempool.space/testnet/tx/bf41b474...8e58355`](https://mempool.space/testnet/tx/bf41b47481a9d1c99af0b62bb36bc864182312f39a3e1e06c8f6304ba8e58355)
+[`mempool.space/testnet/tx/bf41b474...a8e58355`](https://mempool.space/testnet/tx/bf41b47481a9d1c99af0b62bb36bc864182312f39a3e1e06c8f6304ba8e58355?showDetails=true)
 
 **Key Observations**:
 
-- The input references UTXO from transaction `34b90a15...1806f7` at index 1
+- The input references UTXO from transaction [`34b90a15...141806f7`](https://mempool.space/testnet/tx/34b90a15d0a9ec9ff3d7bed2536533c73278a9559391cb8c9778b7e7141806f7?showDetails=true) at index 1
 - The output sends 29,400 satoshis to a SegWit address
 - The transaction fee is 206 satoshis (29,606 - 29,400)
 - The signature verification proves ownership of the private key without revealing it

--- a/book/manuscript/Chapter 03 P2SH Script Engineering - From Multi-signature to Time Locks.md
+++ b/book/manuscript/Chapter 03 P2SH Script Engineering - From Multi-signature to Time Locks.md
@@ -156,7 +156,7 @@ def spend_multisig_p2sh():
 
 Let's trace through the complete script execution using our real transaction data, understanding Bitcoin Core's two-phase P2SH execution mechanism:
 
-**Transaction ID**: [`e68bef53...0fd4e0`](https://mempool.space/testnet/tx/e68bef534c7536300c3ae5ccd0f79e031cab29d262380a37269151e8ba0fd4e0)
+**Transaction ID**: [`e68bef53...ba0fd4e0`](https://mempool.space/testnet/tx/e68bef534c7536300c3ae5ccd0f79e031cab29d262380a37269151e8ba0fd4e0?showDetails=true)
 
 ## Phase 1: ScriptSig + ScriptPubKey Execution
 
@@ -314,7 +314,7 @@ CheckSequenceVerify (CSV) enables relative time locks, where spending is delayed
 
 ### Real-World Implementation: 3-Block Time Lock
 
-**Transaction ID**: [`34f5bf0c...61906f`](https://mempool.space/testnet/tx/34f5bf0cf328d77059b5674e71442ded8cdcfc723d0136733e0dbf180861906f)
+**Transaction ID**: [`34f5bf0c...0861906f`](https://mempool.space/testnet/tx/34f5bf0cf328d77059b5674e71442ded8cdcfc723d0136733e0dbf180861906f?showDetails=true)
 
 This transaction demonstrates a P2SH script that combines CSV time lock with P2PKH signature verification—a common pattern for inheritance and escrow applications.
 

--- a/book/manuscript/Chapter 04 Building SegWit Transactions - From Construction to Stack Execution and Witness Structure and Malleability Solutions.md
+++ b/book/manuscript/Chapter 04 Building SegWit Transactions - From Construction to Stack Execution and Witness Structure and Malleability Solutions.md
@@ -140,7 +140,7 @@ From: tb1qckeg66a6jx3xjw5mrpmte5ujjv3cjrajtvm9r4
 To:   tb1qckeg66a6jx3xjw5mrpmte5ujjv3cjrajtvm9r4
 ```
 
-**Note:** This example uses a real testnet transaction that was successfully broadcast. The transaction TXID is [`271cf628...084e3e6`](https://mempool.space/testnet/tx/271cf6285479885a5ffa4817412bfcf55e7d2cf43ab1ede06c4332b46084e3e6).
+**Note:** This example uses a real testnet transaction that was successfully broadcast. The transaction TXID is [`271cf628...6084e3e6`](https://mempool.space/testnet/tx/271cf6285479885a5ffa4817412bfcf55e7d2cf43ab1ede06c4332b46084e3e6?showDetails=true).
 
 ## 4.3 SegWit Transaction Construction and Analysis
 

--- a/book/manuscript/Chapter 05 Taproot The Evolution of Bitcoins Script System.md
+++ b/book/manuscript/Chapter 05 Taproot The Evolution of Bitcoins Script System.md
@@ -377,7 +377,7 @@ tx, signature = create_simple_taproot_transaction()
 
 ## Real Transaction Analysis
 
-Let's examine a real Taproot transaction: [`a3b4d038...7a42cb6`](https://mempool.space/testnet/tx/a3b4d0382efd189619d4f5bd598b6421e709649b87532d53aecdc76457a42cb6)
+Let's examine a real Taproot transaction: [`a3b4d038...57a42cb6`](https://mempool.space/testnet/tx/a3b4d0382efd189619d4f5bd598b6421e709649b87532d53aecdc76457a42cb6?showDetails=true)
 
 **Transaction Structure:**
 ```

--- a/book/manuscript/Chapter 06 Building Real Taproot Contracts - Single-Leaf Hash Lock and Dual-Path Spending.md
+++ b/book/manuscript/Chapter 06 Building Real Taproot Contracts - Single-Leaf Hash Lock and Dual-Path Spending.md
@@ -353,7 +353,7 @@ preimage_hex = preimage.encode('utf-8').hex()
 
 After running the above code, we can observe real transactions on testnet:
 
-**Transaction ID**: [`68f7c8f0...2e604f`](https://mempool.space/testnet/tx/68f7c8f0ab6b3c6f7eb037e36051ea3893b668c26ea6e52094ba01a7722e604f)
+**Transaction ID**: [`68f7c8f0...722e604f`](https://mempool.space/testnet/tx/68f7c8f0ab6b3c6f7eb037e36051ea3893b668c26ea6e52094ba01a7722e604f?showDetails=true)
 
 **Witness Data Analysis**:
 


### PR DESCRIPTION
Apply the formatting rule we applied to chapter 7 to chapters 1-6 as well:
- symmetric txid abbreviation with internal ellipsis (8 hex chars on each side)
- query parameter showDetails set to true, since we're deep into Bitcoin Script/Tapscript investigation